### PR TITLE
/builder: clear the response panel when the query isn't ready

### DIFF
--- a/src/node_modules/app/machines/builder/form.config.js
+++ b/src/node_modules/app/machines/builder/form.config.js
@@ -98,10 +98,6 @@ export const formConfig = {
 						CheckMatching: {
 							on: {
 								'': [
-									{
-										target: 'Matching',
-										cond: 'isMatching'
-									},
 									{ target: 'Dirty' }
 								]
 							}

--- a/src/node_modules/app/machines/builder/form.config.js
+++ b/src/node_modules/app/machines/builder/form.config.js
@@ -98,6 +98,10 @@ export const formConfig = {
 						CheckMatching: {
 							on: {
 								'': [
+									{
+										target: 'Matching',
+										cond: 'isMatching'
+									},
 									{ target: 'Dirty' }
 								]
 							}

--- a/src/node_modules/app/machines/builder/form.config.js
+++ b/src/node_modules/app/machines/builder/form.config.js
@@ -35,7 +35,6 @@ export const formConfig = {
 		},
 		SelectionIncomplete: {
 			entry: [
-				'setNotReadyStatus',
 				'clearQuery',
 				'clearTypings',
 				'sendSelectionIncomplete',
@@ -94,6 +93,7 @@ export const formConfig = {
 				QueryReady: {
 					id: 'QueryReady',
 					initial: 'CheckMatching',
+					exit: 'setNotReadyStatus',
 					states: {
 						CheckMatching: {
 							on: {
@@ -120,7 +120,6 @@ export const formConfig = {
 							},
 							states: {
 								Idle: {
-									entry: 'setNotReadyStatus',
 									on: {
 										'': [
 											{

--- a/src/node_modules/app/machines/builder/form.config.js
+++ b/src/node_modules/app/machines/builder/form.config.js
@@ -21,7 +21,7 @@ export const formConfig = {
 	},
 	states: {
 		CheckingSelection: {
-			onEntry: 'computeLists',
+			entry: 'computeLists',
 			on: {
 				'': [
 					{
@@ -34,7 +34,7 @@ export const formConfig = {
 			}
 		},
 		SelectionIncomplete: {
-			onEntry: [
+			entry: [
 				'setNotReadyStatus',
 				'clearQuery',
 				'clearTypings',
@@ -44,7 +44,7 @@ export const formConfig = {
 		},
 		SelectionComplete: {
 			initial: 'CheckingQuery',
-			onEntry: [
+			entry: [
 				'computeTypings',
 				'computeDefaultValues'
 			],
@@ -77,7 +77,7 @@ export const formConfig = {
 				},
 				CheckingQuery: {
 					id: 'CheckingQuery',
-					onEntry: 'computeRequest',
+					entry: 'computeRequest',
 					on: {
 						'': [
 							{
@@ -104,6 +104,7 @@ export const formConfig = {
 						},
 						Matching: {
 							id: 'Matching',
+							entry: 'setMatchingStatus'
 						},
 						Dirty: {
 							id: 'Dirty',
@@ -115,7 +116,7 @@ export const formConfig = {
 							},
 							states: {
 								Idle: {
-									onEntry: 'setDirtyStatus',
+									entry: 'setNotReadyStatus',
 									on: {
 										'': [
 											{
@@ -126,7 +127,7 @@ export const formConfig = {
 									}
 								},
 								CheckingCache: {
-									onEntry: [
+									entry: [
 										'computeCacheKey',
 										'sendCommitted',
 									],
@@ -145,7 +146,7 @@ export const formConfig = {
 									}
 								},
 								Pending: {
-									onEntry: 'setPendingStatus',
+									entry: 'setPendingStatus',
 									invoke: {
 										id: 'Pending',
 										src: 'apiRequest',
@@ -153,19 +154,20 @@ export const formConfig = {
 											target: '#Matching',
 											actions: [
 												'storeInCache',
-												'setResponse',
-												'setMatchingStatus'
+												'setResponse'
 											]
 										},
 										onError: {
 											target: '#Error',
-											actions: 'setErrorStatus'
 										}
 									}
 								},
 								Error: {
 									id: 'Error',
-									onEntry: 'setErrorResponse'
+									entry: [
+										'setErrorResponse',
+										'setErrorStatus'
+									]
 								}
 							}
 						}

--- a/src/node_modules/app/machines/builder/form.config.js
+++ b/src/node_modules/app/machines/builder/form.config.js
@@ -35,6 +35,7 @@ export const formConfig = {
 		},
 		SelectionIncomplete: {
 			onEntry: [
+				'setNotReadyStatus',
 				'clearQuery',
 				'clearTypings',
 				'sendSelectionIncomplete',
@@ -118,6 +119,7 @@ export const formConfig = {
 							},
 							states: {
 								Idle: {
+									onEntry: 'setDirtyStatus',
 									on: {
 										'': [
 											{
@@ -147,6 +149,7 @@ export const formConfig = {
 									}
 								},
 								Pending: {
+									onEntry: 'setPendingStatus',
 									invoke: {
 										id: 'Pending',
 										src: 'apiRequest',

--- a/src/node_modules/app/machines/builder/form.context.js
+++ b/src/node_modules/app/machines/builder/form.context.js
@@ -28,9 +28,9 @@ export function createFormStores () {
 		readyForRequest: writable(false),
 		response: writable(null),
 		responseStatus: writable({
-			pending: false,
+			error: false,
 			matching: false,
-			error: false
+			pending: false,
 		})
 	}
 }

--- a/src/node_modules/app/machines/builder/form.options.js
+++ b/src/node_modules/app/machines/builder/form.options.js
@@ -382,11 +382,6 @@ function clearQuery (ctx) {
 const cache = {};
 function doQuery (ctx) {
 	ctx.response.set(null);
-	ctx.responseStatus.set({
-		pending: true,
-		matching: false,
-		error: false
-	});
 	return request('POST', ctx.url, {data: getQuery(ctx)});
 }
 
@@ -407,21 +402,36 @@ function storeInCache (ctx, event) {
 	cache[ctx.cacheKey] = event.data;
 	return ctx;
 }
-function setMatchingStatus (ctx) {
+function setNotReadyStatus (ctx) {
 	ctx.responseStatus.set({
+		error: false,
+		matching: false,
 		pending: false,
-		matching: true,
-		error: false
 	});
 	return ctx;
 }
 function setErrorStatus (ctx) {
 	ctx.responseStatus.set({
-		pending: false,
+		error: true,
 		matching: false,
-		error: true
+		pending: false,
 	});
 	return ctx;
+}
+function setMatchingStatus (ctx) {
+	ctx.responseStatus.set({
+		error: false,
+		matching: true,
+		pending: false,
+	});
+	return ctx;
+}
+function setPendingStatus (ctx) {
+	ctx.responseStatus.set({
+		error: false,
+		matching: false,
+		pending: true,
+	});
 }
 function setResponse (ctx, event) {
 	ctx.response.set(event.data)
@@ -509,6 +519,10 @@ export const formOptions = {
 			formId: ctx.id,
 		})),
 		/**
+		 * Set the response status to dirty.
+		 */
+		setNotReadyStatus: assign(setNotReadyStatus),
+		/**
 		 * Sets the error response in the context after a failed request.
 		 */
 		setErrorResponse: assign(setErrorResponse),
@@ -524,6 +538,10 @@ export const formOptions = {
 		 * Set the response status to matching.
 		 */
 		setMatchingStatus: assign(setMatchingStatus),
+		/**
+		 * Set the response status to pedning.
+		 */
+		setPendingStatus: assign(setPendingStatus),
 		/**
 		 * Store changes in input values in the context.
 		 */

--- a/src/node_modules/app/machines/builder/form.options.js
+++ b/src/node_modules/app/machines/builder/form.options.js
@@ -390,7 +390,7 @@ function isInCache (ctx) {
 }
 
 function isMatching (ctx) {
-	return ctx.cacheKey === `${ctx.url}/${JSON.stringify(getQuery(ctx))}`;
+	return get(ctx.response) && ctx.cacheKey === `${ctx.url}/${JSON.stringify(getQuery(ctx))}`;
 }
 
 function loadFromCache (ctx) {


### PR DESCRIPTION
Closes #197

- Fixed: The response panel now clears if the query isn't ready.