### PR TITLE
CI/CD with Github actions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,0 +1,27 @@
+name: Push to remote
+
+on:
+  push:
+    branches:
+      - 'dev'
+      - 'staging'
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with: 
+          fetch-depth: 0
+      - name: Push to remote server
+        env:
+          PRIVATE_KEY: ${{ secrets.BACKEND_SSH_PRIVATE_KEY }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          install -m 600 -D /dev/null ~/.ssh/private-key.pem
+          echo "$PRIVATE_KEY" > ~/.ssh/private-key.pem
+          ssh-keyscan -H dapsboard.cache.$BRANCH.dap-tools.uk > ~/.ssh/known_hosts
+          git config core.sshCommand 'ssh -i ~/.ssh/private-key.pem' 
+          git remote add $BRANCH ubuntu@dapsboard.cache.$BRANCH.dap-tools.uk:/home/ubuntu/dapsboard.git
+          git push $BRANCH --force

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -1,0 +1,40 @@
+# Creating the hook on the remote server
+
+Create a bare git repo:
+
+```sh
+mkdir dapsboard.git
+cd dapsboard.git
+git init --bare
+```
+
+Create post-receive hook file
+
+```sh
+cd hooks
+touch post-receive
+```
+
+Copy contents of [post-receive](./post-receive) to this file. Make sure you
+update the `branch` variable to reflect which one the remote is, i.e. either
+`dev` or `staging`, then make executable:
+
+```
+sudo chmod +x post-receive
+```
+
+Clone the bare repo:
+
+```
+cd $HOME
+git clone dapsboard.git
+```
+
+Make sure that docker is part of the sudo group:
+
+```sh
+sudo groupadd docker
+sudo usermod -aG docker $USER
+```
+
+And you're done. The GH action will take care of the rest.

--- a/githooks/post-receive
+++ b/githooks/post-receive
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Change this to staging on the staging server
+branch="dev"
+
+while read oldrev newrev ref
+do
+    if [[ $ref =~ .*/$branch$ ]]; then
+        echo "$branch ref received. Deploying $branch branch..."
+        git --work-tree=$HOME/dapsboard --git-dir=$HOME/dapsboard.git checkout $branch -f
+        cd $HOME/dapsboard/be
+        docker compose down
+        docker compose build
+        docker compose up -d
+    else
+        echo "Ref $ref successfully received.  Doing nothing: only the $branch branch may be deployed on this server."
+    fi
+done


### PR DESCRIPTION
When a PR request has finished, the push event on the dev branch triggers an action which pushes the latest version of the branch to the dev server. On the dev server, a post-recieve hook tears down the existing docker containers, builds the latest version of the api, then runs them again.

closes #284