### PR TITLE
Use regex for cors logic

### DIFF
--- a/be/src/conf.js
+++ b/be/src/conf.js
@@ -1,6 +1,6 @@
 export const CROSS_ORIGIN_DOMAINS = [
-	'https://dapsboard-dev.netlify.app',
-	'https://dapsboard-staging.netlify.app'
+	/.*dapsboard-dev\.netlify\.app/u,
+	/.*dapsboard-staging\.netlify\.app/u
 ];
 
 export const PROTECTED_DATASETS = [

--- a/be/src/hooks.js
+++ b/be/src/hooks.js
@@ -8,6 +8,16 @@ import {CROSS_ORIGIN_DOMAINS, PROTECTED_DATASETS} from './conf.js';
 
 const AUTH_ENDPOINT = 'https://authentication.dap-tools.uk/authenticate';
 
+const isCrossOriginRequestAuthorised = request => {
+	const {origin} = request.headers;
+	const isAllowed = _.reduce(
+		CROSS_ORIGIN_DOMAINS,
+		(acc, curr) => acc || curr.test(origin),
+		false
+	)
+	return isAllowed
+}
+
 export const authenticationHook = async req => {
 
 	req.notAuthorised = false;
@@ -27,7 +37,7 @@ export const authenticationHook = async req => {
 		}
 	} else {
 		// check that the non-signed request is coming from dapsboard
-		if (!_.isIn(CROSS_ORIGIN_DOMAINS, req.headers.origin)) {
+		if (!isCrossOriginRequestAuthorised(req)) {
 			req.notAuthorised = true;
 			req.errorMessage = 'CORS policy is blocking this request';
 		}


### PR DESCRIPTION
We need some regex to allow the Netlify preview deployments to also access the dev and staging servers.

closes #296