### PR TITLE
Fix docker/mongo auth bug on ci/cd

### DIFF
--- a/githooks/README.md
+++ b/githooks/README.md
@@ -15,9 +15,14 @@ cd hooks
 touch post-receive
 ```
 
-Copy contents of [post-receive](./post-receive) to this file. Make sure you
-update the `branch` variable to reflect which one the remote is, i.e. either
-`dev` or `staging`, then make executable:
+Copy contents of [post-receive](./post-receive) to this file. 
+
+Please make sure that you:
+- Update the `branch` variable to reflect which one the remote is, i.e. either
+  `dev` or `staging`
+- Set the `MONGO_ROOT_USER` and `MONGO_ROOT_PASSWORD` variables in the script
+
+Then make executable:
 
 ```
 sudo chmod +x post-receive

--- a/githooks/post-receive
+++ b/githooks/post-receive
@@ -9,6 +9,8 @@ do
         echo "$branch ref received. Deploying $branch branch..."
         git --work-tree=$HOME/dapsboard --git-dir=$HOME/dapsboard.git checkout $branch -f
         cd $HOME/dapsboard/be
+        export MONGO_ROOT_USER=<your_root_user>
+        export MONGO_ROOT_PASSWORD=<your_root_password>
         docker compose down
         docker compose build
         docker compose up -d


### PR DESCRIPTION
Document the fact that the post-receive git hook on the server needs to export the correct Mongo authentication evironment variables in order to re-authenticate when we call docker up.

fixes #311